### PR TITLE
Use v prefix for release tags

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,10 +16,8 @@ name: Package
 
 on:
   push:
-    branches:
-      - master
     tags:
-      - '*'
+      - v*
 
 jobs:
   publish:


### PR DESCRIPTION
Only build release packages for tags that start with a "v".