### PR TITLE
Strip v from version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,12 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,11 +20,13 @@ on:
       - v*
 
 jobs:
-  publish:
+  package:
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout the code
         uses: actions/checkout@v1
@@ -38,4 +40,4 @@ jobs:
         env:
           GITHUB_USER: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew printInfo publish -Pversion="${GITHUB_REF:10}"
+        run: ./gradlew printInfo publish -Pversion="${GITHUB_REF:11}"


### PR DESCRIPTION
The version number for the build artefact should not include the "v" prefix from the Git tag.